### PR TITLE
Democratizing rendering

### DIFF
--- a/ThaumatoAnakalyptor/memmap_to_layers.py
+++ b/ThaumatoAnakalyptor/memmap_to_layers.py
@@ -1,0 +1,230 @@
+## Giorgio Angelotti - 2024
+## Based on ppm_to_layers by Julian Schilinger
+
+from rendering_utils.interpolate_image_3d import extract_from_image_3d, insert_into_image_3d
+from grid_to_pointcloud import load_grid
+import argparse
+from tqdm import tqdm
+import os
+import tifffile
+import numpy as np
+import torch
+from concurrent.futures import ThreadPoolExecutor, as_completed
+# nr threads
+import multiprocessing
+
+from PIL import Image
+Image.MAX_IMAGE_PIXELS = None
+
+layers = None
+
+def process_chunk(data_chunk, offset_x, offset_y, cube_size):
+    cube_chunk = {}
+    # Create a mask for rows where the first three elements are not all zeroes
+    mask = np.any(data_chunk[:, :, :3] != 0, axis=2)
+    for imx in range(data_chunk.shape[0]):
+        for imy in range(data_chunk.shape[1]):
+            if mask[imx, imy]:  # Only process if the mask at (imx, imy) is True
+                key = tuple(np.floor(data_chunk[imx, imy, :3] / cube_size).astype(np.int32))
+                if key not in cube_chunk:
+                    cube_chunk[key] = [[imx + offset_x, imy + offset_y]]
+                else:
+                    cube_chunk[key].append([imx + offset_x, imy + offset_y])
+    return cube_chunk
+
+
+
+def merge_dictionaries(dicts):
+    """Merge dictionaries, combining lists of coordinates for the same key."""
+    result = {}
+    for d in dicts:
+        for key, value in d.items():
+            if key in result:
+                result[key].extend(value)
+            else:
+                result[key] = value
+    return result
+
+
+def classify_entries_to_cubes(cube_size, start, data):
+    chunk_size_x, chunk_size_y = 256, 256  # Example sizes
+    chunks = []
+
+    for start_x in range(0, data.shape[0], chunk_size_x):
+        for start_y in range(0, data.shape[1], chunk_size_y):
+            end_x = min(start_x + chunk_size_x, data.shape[0])
+            end_y = min(start_y + chunk_size_y, data.shape[1])
+            chunks.append((data[start_x:end_x, start_y:end_y, :], start_x+start[0], start_y+start[1]))
+
+    # Process chunks in parallel
+    with ThreadPoolExecutor() as executor:
+        futures = [executor.submit(process_chunk, chunk[0], chunk[1], chunk[2], cube_size) for chunk in chunks]
+        partial_results = [future.result() for future in futures]
+
+    # Merge the partial results
+    cube = merge_dictionaries(partial_results)
+    return cube
+
+def calculate_chunk_indices(coords, start_coords, chunk_sizes):
+    # Adjust coords relative to the start of the grid
+    adjusted_coords = coords - start_coords
+    
+    # Calculate chunk indices for each coordinate
+    chunk_indices = adjusted_coords // chunk_sizes
+    
+    return chunk_indices
+
+def global_to_chunk_coords(coords, start_coords, chunk_sizes):
+    chunk_sizes = torch.tensor(chunk_sizes)
+    # Adjust coords relative to the start of the grid
+    adjusted_coords = coords - start_coords
+    
+    # Calculate chunk indices for each coordinate
+    chunk_indices = adjusted_coords // chunk_sizes
+
+    # Calculate the start of each coordinate's chunk
+    chunk_starts = chunk_indices * chunk_sizes
+    
+    # Calculate local (chunk) coordinates
+    chunk_coords = adjusted_coords - chunk_starts
+    
+    return chunk_coords, chunk_indices
+
+def load_and_process_grid_volume(cubes, cube, data, args, path_template, axis_swap_trans, gpu_num):
+    # construct volume indexing
+    device = 'cpu'
+    cube_ppm = cubes[cube]
+    # Vectorize the extraction of xyz and normals directly without loop
+    imx, imy = np.transpose(cube_ppm)  # Transpose to separate x and y
+    cube_image_positions = np.vstack((imy, imx)).T.astype(np.int32)
+    
+    xyz = torch.from_numpy(data[imx, imy, :3])
+    normals = torch.from_numpy(data[imx, imy, 3:])
+    # construct all coordinate in positive and negative r
+    coords = torch.cat([xyz + r * normals for r in range(-args.r, args.r+1)], dim=0)
+
+    # find min and max values in each dimension
+    coords_cpu = coords.cpu().numpy()
+    min_coords = np.min(coords_cpu, axis=0).astype(np.int32)
+    max_coords = np.max(coords_cpu, axis=0).astype(np.int32)
+    start_coords = np.array(min_coords).astype(np.int32)
+    axis_swap = [1, 0, 2]
+    start_coords = start_coords[axis_swap] + args.cube_size
+    #print(start_coords)
+    grid_block_size = np.array(max_coords - min_coords + 1).astype(np.int32)[axis_swap]
+    
+    grid_volume = load_grid(path_template, tuple(start_coords), grid_block_size, args.cube_size, uint8=False).astype(np.float64)
+    grid_volume = np.transpose(grid_volume.copy(), axes=axis_swap_trans)
+    grid_volume = torch.from_numpy(grid_volume)
+    
+    #device = torch.device("cuda:" + str(gpu_num))
+    # recalculate coords to zero on grid_volume
+    coords = coords - torch.tensor(min_coords, dtype=torch.float64, device=device)
+    
+    # extract from grid volume
+    samples = extract_from_image_3d(grid_volume, coords).cpu()
+    del grid_volume
+    del coords
+    
+
+    
+    xy = torch.tensor(cube_image_positions, dtype=torch.int32).cpu()  # x, y coordinates
+    # construct z coordinates for each layer
+    z_layers = torch.arange(0, 2*args.r+1, dtype=torch.int32).repeat(len(cube_ppm), 1).T.contiguous().view(-1).cpu()
+    # repeat xy coordinates for each layer
+    xy_repeated = xy.repeat(2*args.r+1, 1)
+    # combine xy and z coordinates
+    xyz_layers = torch.cat([z_layers[:, None], xy_repeated], dim=1).cpu()  # z, x, y order
+
+    global layers
+    insert_into_image_3d(samples, xyz_layers, layers)
+
+def main(args):
+    working_path = os.path.dirname(args.ppm_path)
+    path_template = args.grid_volume_path + "/cell_yxz_{:03}_{:03}_{:03}.tif"
+
+    base_name = os.path.splitext(os.path.basename(args.ppm_path))[0]
+
+    # Construct the potential paths for the .tif and .png files
+    tif_path = os.path.join(working_path, f"{base_name}.tif")
+    png_path = os.path.join(working_path, f"{base_name}.png")
+
+    # Check if the .tif version exists
+    if os.path.exists(tif_path):
+        image_path = tif_path
+        print(f"Found TIF image at: {image_path}", end="\n")
+    # If not, check if the .png version exists
+    elif os.path.exists(png_path):
+        image_path = png_path
+        print(f"Found PNG image at: {image_path}", end="\n")
+    # If neither exists, handle the case (e.g., error message)
+    else:
+        image_path = None
+        print("No corresponding TIF or PNG image found.", end="\n")
+    
+    # Open the image file
+    with Image.open(image_path) as img:
+        # Get dimensions
+        im_shape = img.size
+
+    # load ppm cubes
+    print("Accessing memmap...", end="\n")
+    data = np.memmap(args.ppm_path, mode='r', dtype=np.float64, shape=(im_shape[0], im_shape[1], 6))
+
+    global layers
+    layers = torch.zeros((2*args.r + 1, im_shape[1], im_shape[0]), dtype=torch.float64, device='cpu')
+
+    layers_path = working_path + "/layers/"
+
+    print(f"All parameters: {args}, im_shape: {im_shape}, layers_path: {layers_path}, path_template: {path_template}")
+    axis_swap_trans = [2, 1, 0]
+
+    for y in tqdm(range(0, im_shape[0], args.block_render), desc='Spanning image'):
+        for x in range(0, im_shape[1], args.block_render):
+            # Process cubes in batches
+            cubes = classify_entries_to_cubes(cube_size=args.cube_size, start=(y, x), data=data[y: min(y+args.block_render, im_shape[0]), x: min(x+args.block_render, im_shape[1])])
+            cube_list = list(cubes.keys())
+            #print(cube_list)
+            total_cubes = len(cube_list)
+            batch_size = args.max_workers  # Process cubes in batches equal to max_workers
+            with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+                with tqdm(total=total_cubes, desc=f"Processing Cubes for {y,x}") as progress:
+                    for i in range(0, total_cubes, batch_size):
+                        gpu_num = i % args.gpus
+                        # Submit a batch of tasks
+                        futures = [executor.submit(load_and_process_grid_volume, cubes, cube, data, args, path_template, axis_swap_trans, gpu_num) for cube in cube_list[i:i+batch_size]]
+
+                        # Process completed tasks before moving on to the next batch
+                        for future in as_completed(futures):
+                            # Update the progress bar each time a future is completed
+                            progress.update(1)
+                            future.result()
+
+
+    # save layers
+    nr_zeros = len(str(2*args.r))
+    for i in range(layers.shape[0]):
+        layer = layers[i].cpu().numpy().astype(np.uint16)
+        # save layer with leading 0's for 2*r layers
+        layer_nr = str(i).zfill(nr_zeros)
+        layer_path = layers_path + f"{layer_nr}.tif"
+        tifffile.imwrite(layer_path, layer)
+
+if __name__ == '__main__':
+    # parse memmap path, grid volume path, r=32, cube_size=500, default, all cores
+    # u can go up with block_render according to your RAM
+    # the algorithm generates the "image" in memory in blocks of pixels block_render x block_render
+    # this chunk processing avoids the allocation of a too big grid in memory, allowing rendering on
+    # a simple laptop
+    parser = argparse.ArgumentParser()
+    parser.add_argument('ppm_path', type=str)
+    parser.add_argument('grid_volume_path', type=str)
+    parser.add_argument('--r', type=int, default=32)
+    parser.add_argument('--cube_size', type=int, default=500)
+    parser.add_argument('--rendering_size', type=int, default=400)
+    parser.add_argument('--block_render', type=int, default=2048)
+    parser.add_argument('--max_workers', type=int, default=multiprocessing.cpu_count()//2)
+    parser.add_argument('--gpus', type=int, default=1)
+    args = parser.parse_args()
+
+    main(args)

--- a/ThaumatoAnakalyptor/obj_to_ppm.py
+++ b/ThaumatoAnakalyptor/obj_to_ppm.py
@@ -60,7 +60,7 @@ def main(args):
     gc.collect()
 
     print(f"Computing coordinates...", end="\n")
-    _, coords3d, norms3d, _ = compute_barycentric(UV_scaled, V, N, F, UV_TARGET, pts_batch_size=args.pts_batch, tri_batch_size=args.tri_batch)
+    _, coords3d, norms3d = compute_barycentric(UV_scaled, V, N, F, UV_TARGET, pts_batch_size=args.pts_batch, tri_batch_size=args.tri_batch)
     print(f"Computed new coordinates and normals.", end="\n")
 
     del UV_scaled, V, N, F, UV_TARGET 

--- a/ThaumatoAnakalyptor/obj_to_ppm.py
+++ b/ThaumatoAnakalyptor/obj_to_ppm.py
@@ -1,0 +1,89 @@
+### Giorgio Angelotti - 2024
+
+from rendering_utils.torch_ppm import compute_barycentric
+from rendering_utils.ppm_writer import PPMWriter
+import open3d as o3d
+import argparse
+import gc
+import os
+import numpy as np
+import torch
+from PIL import Image
+Image.MAX_IMAGE_PIXELS = None
+
+def main(args):
+    working_path = os.path.dirname(args.obj_path)
+    base_name = os.path.splitext(os.path.basename(args.obj_path))[0]
+    ppm_path = os.path.join(working_path, f"{base_name}.ppm")
+
+    # Construct the potential paths for the .tif and .png files
+    tif_path = os.path.join(working_path, f"{base_name}.tif")
+    png_path = os.path.join(working_path, f"{base_name}.png")
+
+    # Check if the .tif version exists
+    if os.path.exists(tif_path):
+        image_path = tif_path
+        print(f"Found TIF image at: {image_path}", end="\n")
+    # If not, check if the .png version exists
+    elif os.path.exists(png_path):
+        image_path = png_path
+        print(f"Found PNG image at: {image_path}", end="\n")
+    # If neither exists, handle the case (e.g., error message)
+    else:
+        image_path = None
+        print("No corresponding TIF or PNG image found.", end="\n")
+    
+    # Open the image file
+    with Image.open(image_path) as img:
+        # Get dimensions
+        y_size, x_size = img.size
+    print(f"Y-size: {y_size}, X-size: {x_size}", end="\n")
+
+    mesh = o3d.io.read_triangle_mesh(args.obj_path)
+    print(f"Loaded mesh from {args.obj_path}", end="\n")
+
+    V = torch.tensor(np.asarray(mesh.vertices))
+    N = torch.tensor(np.asarray(mesh.vertex_normals))
+    UV = torch.tensor(np.asarray(mesh.triangle_uvs))  # Ensure your mesh has UV coordinates
+    F = torch.tensor(np.asarray(mesh.triangles))
+
+    # Adjust UV coordinates as per the requirement
+    UV_scaled = UV * torch.tensor([y_size, x_size])
+
+    # Generate UV_TARGET
+    x = torch.arange(x_size, 0, -1)
+    y = torch.arange(0, y_size, 1)
+    grid_x, grid_y = torch.meshgrid(x, y, indexing='ij')
+    UV_TARGET = torch.stack([grid_y.flatten(), grid_x.flatten()], dim=1).to(torch.float64)
+    print(f"Created grid.", end="\n")
+    del mesh, x, y, grid_x, grid_y, UV
+    gc.collect()
+
+    print(f"Computing coordinates...", end="\n")
+    _, coords3d, norms3d, _ = compute_barycentric(UV_scaled, V, N, F, UV_TARGET, pts_batch_size=args.pts_batch, tri_batch_size=args.tri_batch)
+    print(f"Computed new coordinates and normals.", end="\n")
+
+    del UV_scaled, V, N, F, UV_TARGET 
+    gc.collect()
+
+    coords = coords3d.numpy()
+    norms = norms3d.numpy()
+
+    del coords3d, norms3d
+    gc.collect()
+
+    writer = PPMWriter(ppm_path, height=x_size, width=y_size)
+    writer.write_header()
+    print(f"Writing PPM...", end="\n")
+    writer.write_coords(coords, norms)
+    print(f"PPM written at {ppm_path}", end="\n")
+if __name__ == '__main__':
+    # parse obj path, process batches of 2048 points, check against 64 near triangles
+    # change the batch sizes according to your resources. A too low tri_batch can affect the result
+    parser = argparse.ArgumentParser()
+    parser.add_argument('obj_path', type=str)
+    parser.add_argument('--pts_batch', type=int, default=2048)
+    parser.add_argument('--tri_batch', type=int, default=64)
+    args = parser.parse_args()
+
+    main(args)

--- a/ThaumatoAnakalyptor/rendering_utils/ppm_writer.py
+++ b/ThaumatoAnakalyptor/rendering_utils/ppm_writer.py
@@ -1,0 +1,36 @@
+### Giorgio Angelotti - 2024
+
+import numpy as np
+import struct
+from tqdm import tqdm
+
+class PPMWriter(object):
+    def __init__(self, filename, width, height):
+        self.filename = filename
+        # Setting width and height from the inputs
+        self.info = {
+            'width': width,
+            'height': height,
+            'dim': 6,
+            'ordered': 'true',
+            'type': 'double',
+            'version': 1
+        }
+
+    def write_header(self):
+        with open(self.filename, 'wb') as f:
+            for key, value in self.info.items():
+                f.write(f"{key}: {value}\n".encode('utf-8'))
+            f.write(b'<>\n')
+
+    def write_coords(self, positions, normals):
+        assert positions.shape[0] == normals.shape[0], "Positions and normals must have the same number of entries"
+        with open(self.filename, 'ab') as f:  # Append binary data
+            for pos, norm in tqdm(zip(positions, normals), total=positions.shape[0], desc="Lines"):
+                # Ensure the data is in double format
+                buf = struct.pack('<' + 'd'*6, *pos, *norm)
+                f.write(buf)
+
+    def create_ppm(self, positions, normals):
+        self.write_header()
+        self.write_coords(positions, normals)

--- a/ThaumatoAnakalyptor/rendering_utils/torch_ppm.py
+++ b/ThaumatoAnakalyptor/rendering_utils/torch_ppm.py
@@ -1,0 +1,103 @@
+### Giorgio Angelotti - 2024
+
+import torch
+from torch.nn.functional import normalize
+from tqdm import tqdm
+from scipy.spatial import KDTree
+
+
+def to_device(tensor, device):
+    """Move tensor to a specified device."""
+    return tensor.to(device, non_blocking=True)
+
+def points_in_triangles(pts, tri_pts):
+    # pts B x 2
+    # tri_pts B x tri x 3 x 2
+    # triangles B x tri x 3
+    v0 = tri_pts[:, :, 2, :] - tri_pts[:, :, 0, :]
+    v1 = tri_pts[:, :, 1, :] - tri_pts[:, :, 0, :]
+    v2 = pts.unsqueeze(1) - tri_pts[:, :, 0, :]
+
+    dot00 = v0.pow(2).sum(dim=2)
+    dot01 = (v0 * v1).sum(dim=2)
+    dot11 = v1.pow(2).sum(dim=2)
+    dot02 = (v2 * v0).sum(dim=2)
+    dot12 = (v2 * v1).sum(dim=2)
+
+    invDenom = 1 / (dot00 * dot11 - dot01.pow(2))
+    u = (dot11 * dot02 - dot01 * dot12) * invDenom
+    v = (dot00 * dot12 - dot01 * dot02) * invDenom
+
+    is_inside = (u >= 0) & (v >= 0) & ((u + v) <= 1 )
+
+    bary_coords = torch.zeros((u.shape[0], 3), dtype=torch.float64, device=u.device)
+    triangle_indices = torch.where(is_inside.any(dim=1), is_inside.float().argmax(dim=1), torch.tensor(-1, device=u.device, dtype=torch.int64))
+    inside_mask = triangle_indices != -1
+
+    u_vals = torch.gather(u[inside_mask], 1, triangle_indices[inside_mask].unsqueeze(1)).squeeze(1)
+    v_vals = torch.gather(v[inside_mask], 1, triangle_indices[inside_mask].unsqueeze(1)).squeeze(1)
+    w_vals = 1 - u_vals - v_vals
+    bary_coords[inside_mask] = torch.stack([u_vals, v_vals, w_vals], dim=1)
+
+    return triangle_indices, bary_coords
+
+def build_kdtree(vertices, triangles):
+    centroids = vertices.view(triangles.size(0), 3, 2).mean(dim=1).cpu().numpy()  # Compute centroids and move to CPU for KDTree
+    kdtree = KDTree(centroids, balanced_tree=True)
+    return kdtree
+
+def query_kdtree(kdtree, points, top_k=16):
+    # Convert points to numpy and query KDTree
+    _, indices = kdtree.query(points.cpu().numpy(), k=top_k, workers=-1)
+    return torch.from_numpy(indices).to(points.device)  # Convert back to tensor and move to original device
+
+
+def points_in_triangles_batched(pts, vertices, triangles, kdtree, pts_batch_size=2048, tri_batch_size=16):
+    device = pts.device
+    num_pts = pts.size(0)
+    final_triangle_indices = torch.full((num_pts,), -1, dtype=torch.int64, device=device)
+    final_bary_coords = torch.zeros((num_pts, 3), dtype=torch.float64, device=device)
+
+    for pts_batch_idx in tqdm(range((num_pts + pts_batch_size - 1) // pts_batch_size), desc="Batch"):
+        pts_start_idx = pts_batch_idx * pts_batch_size
+        pts_end_idx = min(pts_start_idx + pts_batch_size, num_pts)
+        batch_pts = pts[pts_start_idx:pts_end_idx]
+
+        # Query KDTree for each point in the batch to find the top 16 closest triangles
+        closest_tri_indices = query_kdtree(kdtree, batch_pts, top_k=tri_batch_size)
+
+        batch_vertices = vertices.view(triangles.size(0), 3, 2)[closest_tri_indices]
+        triangle_indices, bary_coords = points_in_triangles(batch_pts, batch_vertices)
+        valid_mask = (triangle_indices != -1).clone()
+        valid_points = valid_mask.nonzero().squeeze()
+
+        # For each valid point, select the correct triangle index from closest_tri_indices
+        if valid_points.numel() > 0:  # Check if there are any valid points
+            valid_tri_indices = triangle_indices[valid_mask]
+            valid_closest_tri_indices = closest_tri_indices[valid_mask,valid_tri_indices]
+            # Update final_triangle_indices for valid points
+            final_triangle_indices[pts_start_idx:pts_end_idx][valid_mask] = valid_closest_tri_indices
+            
+            # Update final_bary_coords for valid points
+            final_bary_coords[pts_start_idx:pts_end_idx][valid_mask] = bary_coords[valid_mask]
+
+    return final_triangle_indices, final_bary_coords
+
+def compute_barycentric(uv, v, normals, faces, target_uv, pts_batch_size=2048, tri_batch_size=16):
+    uv = uv.to(torch.float64)
+    # Compute centroids of the triangles and build KDTree
+    kdtree = build_kdtree(uv, faces)
+    triangle_indices, bary_coords = points_in_triangles_batched(target_uv, uv, faces, kdtree, pts_batch_size=pts_batch_size, tri_batch_size=tri_batch_size)
+    bary_coords = normalize(bary_coords, p=1, dim=1)
+
+    tri_v = v[faces[triangle_indices,:]]
+    tri_norm = normals[faces[triangle_indices,:]]
+
+    new_order = [2,1,0]
+    tri_v = tri_v[:,new_order,:]
+    tri_norm = tri_norm[:,new_order,:]
+
+    coord_in_v = torch.einsum('ijk,ij->ik', tri_v, bary_coords).squeeze()
+    norm_in_v = normalize(torch.einsum('ijk,ij->ik', tri_norm, bary_coords).squeeze(),dim=1)
+
+    return bary_coords, coord_in_v, norm_in_v, triangle_indices

--- a/ThaumatoAnakalyptor/rendering_utils/torch_ppm.py
+++ b/ThaumatoAnakalyptor/rendering_utils/torch_ppm.py
@@ -49,11 +49,12 @@ def build_kdtree(vertices, triangles):
 def query_kdtree(kdtree, points, top_k=16):
     # Convert points to numpy and query KDTree
     _, indices = kdtree.query(points.cpu().numpy(), k=top_k, workers=-1)
-    return torch.from_numpy(indices).to(points.device)  # Convert back to tensor and move to original device
+    return torch.from_numpy(indices)  # Convert back to tensor and move to original device
 
 
 def points_in_triangles_batched(pts, vertices, triangles, kdtree, pts_batch_size=2048, tri_batch_size=16):
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    #device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    device = 'cpu'
     num_pts = pts.size(0)
     final_triangle_indices = torch.full((num_pts,), -1, dtype=torch.int64, device=device)
     final_bary_coords = torch.zeros((num_pts, 3), dtype=torch.float64, device=device)


### PR DESCRIPTION
This PR **democratizes rendering** with the following scripts:

1. `obj_to_ppm.py`
2. `torch_ppm.py`
3. `memmap_to_layers.py`

**`obj_to_ppm.py`** and **`torch_ppm.py`** allow one to convert a segment mesh (`.obj`) into a per-pixel-map saved as a numpy memory mapped file. The conversion is very **FAST**. When reading the flattened UVs, the centroid of each triangle face is batch computed using torch, and a KDTree is built on this structure. A grid of new points is added in 2D at integer locations. These points will be the pixels of the rendered image. The KDTree is queried to quickly identify the *M* (`--tri_batch` parameter) closest triangles to each point. In a batched and parallelized way, always using torch, the barycentric coordinates for every point in each of its *M* candidate triangles are computed. If for some couple (point - triangle) the barycentric coordinates are in \[0,1\] and sum up to 1, then the said pair is chosen. Always in a batched and parallelized way with torch, exploiting the barycentric coordinates, the position (and normals) in the 3D scroll volume are obtained by barycentric interpolation. Periodically (and automatically lol) the computed information for the batches is flushed into the ppm memmap.

**`memmap_to_layers.py`** is a modification of Julian's `ppm_to_layers.py`. It reads the saved ppm that is saved as a numpy memmap in batches, exploiting the slicing properties of a numpy array, and updates the rendered pixels. Since the operation is batched, one can render even a huge segment on a cheap laptop (mine is an i7 with 16GB RAM and no GPU).

At the moment, GPU compatibility isn't working since I could not test it locally. But the scripts can be easily readapted to make it work.

Bonus `ppm_writer.py` could be used to save the computed ppm in the `.ppm` format used by Virtual Cartographer, however, the logic of `obj_to_ppm.py` should be changed (I was using it in an older version, before switching to numpy memmap).