### PR TITLE
Various pointcloud optimizations - no quantitative changes

### DIFF
--- a/ThaumatoAnakalyptor/surface_detection.py
+++ b/ThaumatoAnakalyptor/surface_detection.py
@@ -143,7 +143,7 @@ def _find_mean_vector_kernel(vectors, random_vectors):
 n_vectors = 200
 find_mean_vector_kernel = torch.jit.trace(_find_mean_vector_kernel, (torch.rand((729,3)), torch.rand((n_vectors,3))))
 
-# Function to find the vector that is the propper mean vector for the input vectors vs when -v = v
+# Function to find the vector that is the proper mean vector for the input vectors vs when -v = v
 def find_mean_indiscriminative_vector(vectors, n, device):
     # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/ThaumatoAnakalyptor/surface_detection.py
+++ b/ThaumatoAnakalyptor/surface_detection.py
@@ -8,26 +8,35 @@ import torch.nn.functional as F
 # test
 import unittest
 
+# we don't want to re-initialize the sobel filter every time, so we just cache the result
+sobel_x = sobel_y = sobel_z = None
+cn = 0
+
 ## sobel_filter_3d from https://github.com/lukeboi/scroll-viewer/blob/dev/server/app.py
 ### adjusted for my use case and improve efficiency
 def sobel_filter_3d(input, chunks=4, overlap=3, device=None):
+    global sobel_x, sobel_y, sobel_z
+    global cn  # count of calls to empty the cache
     # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     input = input.unsqueeze(0).unsqueeze(0).to(device, dtype=torch.float16)
 
     # Define 3x3x3 kernels for Sobel operator in 3D
-    sobel_x = torch.tensor([
-        [[[ 1, 0, -1], [ 2, 0, -2], [ 1, 0, -1]],
-         [[ 2, 0, -2], [ 4, 0, -4], [ 2, 0, -2]],
-         [[ 1, 0, -1], [ 2, 0, -2], [ 1, 0, -1]]],
-    ], dtype=torch.float16).to(device)
+    if  sobel_x is None:
+        print('initializing sobel')
+        sobel_x = torch.tensor([
+            [[[ 1, 0, -1], [ 2, 0, -2], [ 1, 0, -1]],
+             [[ 2, 0, -2], [ 4, 0, -4], [ 2, 0, -2]],
+             [[ 1, 0, -1], [ 2, 0, -2], [ 1, 0, -1]]],
+        ], dtype=torch.float16).to(device)
 
-    sobel_y = sobel_x.transpose(1, 3)
-    sobel_z = sobel_x.transpose(2, 3)
 
-    # Add an extra dimension for the input channels
-    sobel_x = sobel_x[None, ...]
-    sobel_y = sobel_y[None, ...]
-    sobel_z = sobel_z[None, ...]
+        sobel_y = sobel_x.transpose(1, 3)
+        sobel_z = sobel_x.transpose(2, 3)
+
+        # Add an extra dimension for the input channels
+        sobel_x = sobel_x[None, ...]
+        sobel_y = sobel_y[None, ...]
+        sobel_z = sobel_z[None, ...]
 
     assert len(input.shape) == 5, "Expected 5D input (batch_size, channels, depth, height, width)"
 
@@ -63,9 +72,10 @@ def sobel_filter_3d(input, chunks=4, overlap=3, device=None):
 
         # Free memory of intermediate variables
         del G_x, G_y, G_z, chunk
-    if torch.cuda.is_available():
+    cn += 1
+    if torch.cuda.is_available() and cn % 10 == 0:
+        # emptying the cache on every iteration isn't free, let's do it once every 10
         torch.cuda.empty_cache()
-
     return vectors.squeeze(0).squeeze(0).to(device, dtype=torch.float16)
 
 ## own code
@@ -84,7 +94,7 @@ def uniform_blur3d(channels=1, size=3, device=None):
     # Repeat the kernel for all input channels
     kernel = kernel.repeat(channels, 1, 1, 1, 1)
     # Create a convolution layer
-    blur_layer = nn.Conv3d(in_channels=channels, out_channels=channels, 
+    blur_layer = nn.Conv3d(in_channels=channels, out_channels=channels,
                            kernel_size=size, groups=channels, bias=False, padding=size//2)
     # Set the kernel weights
     blur_layer.weight.data = nn.Parameter(kernel)
@@ -95,50 +105,53 @@ def uniform_blur3d(channels=1, size=3, device=None):
 
 # Function to normalize vectors to unit length
 def normalize(vectors):
-    # Find 0 vectors and make them 1, 0, 0
-    # vectors_norm = vectors.norm(dim=-1, keepdim=True).expand(vectors.shape)
-    # zero_vectors = vectors_norm == 0
-    # vectors[zero_vectors] = torch.tensor([1.0, 0.0, 0.0], device=vectors.device, dtype=vectors.dtype)
-
     return vectors / vectors.norm(dim=-1, keepdim=True).expand(vectors.shape)
 
-# Function to calculate angular distance between vectors
+# Function to calculate angular distance between vectors - returns an angle in [0, pi/2], the undirected angle
 def angular_distance(v1, v2):
     v1 = v1.unsqueeze(0) if v1.dim() == 1 else v1
     v2 = v2.unsqueeze(0) if v2.dim() == 1 else v2
     dot_v1_v2 = (v1 * v2).sum(-1)
     # print(f"Dot product: {dot_v1_v2}")
-    return torch.acos(torch.clamp(dot_v1_v2, -1.0, 1.0))
+    return torch.acos(torch.abs(torch.clamp(dot_v1_v2, -1.0, 1.0)))
 
 # Mean indiscriminative Loss function for a batch of candidate vectors and a batch of input vectors
 def loss(candidates, vectors):
     # Prepare for pairwise loss
     candidates_expanded = candidates.unsqueeze(1).expand(-1, vectors.shape[0], -1)
     vectors_expanded = vectors.unsqueeze(0).expand(candidates.shape[0], -1, -1)
-    # pairwise angulare distance
-    pos_distance = torch.abs(angular_distance(candidates_expanded, vectors_expanded))
-    neg_distance = torch.abs(angular_distance(-candidates_expanded, vectors_expanded))
+    # pairwise angulare distance - we only need one direction because we're taking the angle over [0, pi/2] not the full range
+    pos_distance = angular_distance(candidates_expanded, vectors_expanded)
     # Find the minimum loss for each candidate-vector pair (flipping the candidate vector)
-    losses = torch.min(torch.stack((pos_distance, neg_distance), dim=-1), dim=-1)[0]
+    losses = pos_distance
     # Reduce to get total loss per candidate
-    summed_loss = losses.sum(dim=-1)    
+    summed_loss = losses.sum(dim=-1)
     return summed_loss
 
-# Function to find the vector that is the propper mean vector for the input vectors vs when -v = v
-def find_mean_indiscriminative_vector(vectors, n, device):
-    # Generate n random unit vectors
-    random_vectors = torch.randn(n, 3, device=device)
-    # Normalize the input vectors
+def _find_mean_vector_kernel(vectors, random_vectors):
+    vectors = normalize(vectors)
     random_vectors = normalize(random_vectors)
-    vectors = normalize(vectors)    
-
     # Compute the total loss for each candidate
     total_loss = loss(random_vectors, vectors)
     # Pick the candidate with the smallest loss over all vectors
     argmin_loss = torch.argmin(total_loss)
-
     # Find the best candidate
     best_vector = random_vectors[argmin_loss]
+    return best_vector
+
+# initialize the mean vector kernel with jit.trace given the number of random vectors to use
+n_vectors = 200
+find_mean_vector_kernel = torch.jit.trace(_find_mean_vector_kernel, (torch.rand((729,3)), torch.rand((n_vectors,3))))
+
+# Function to find the vector that is the propper mean vector for the input vectors vs when -v = v
+def find_mean_indiscriminative_vector(vectors, n, device):
+    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Generate n random unit vectors
+    random_vectors = torch.randn(n, 3, device=device)
+    # Normalize the input vectors
+    vectors = normalize(vectors)
+    best_vector = find_mean_vector_kernel(vectors, random_vectors)
     return best_vector
 
 # Function to adjust the amplitude of the mean vector to the mean amplitude of the input vectors
@@ -155,26 +168,26 @@ def vector_projection(a, b):
 def adjusted_norm(a, b):
     # Calculate the projection
     projection = vector_projection(a, b)
-    
+
     # Compute the dot product of the projected vector and the original vector b
     dot_product = (projection * b).sum(-1)
-    
+
     # Compute the norm of the projection
     projection_norm = projection.norm(dim=-1)
-    
+
     # Adjust the norm based on the sign of the dot product
     adjusted_norm = torch.sign(dot_product) * projection_norm
     # print(f"shape adjusted_norm: {adjusted_norm.shape}")
-    
+
     return adjusted_norm
 
 def scale_to_0_1(tensor):
     # Compute the 99th percentile
     #quantile_val = torch.quantile(tensor, 0.95)
-    
+
     # Clip the tensor values at the 99th percentile
     clipped_tensor = torch.clamp(tensor, min=-1000, max=1000)
-    
+
     # Scale the tensor to the range [0,1]
     tensor_min = torch.min(clipped_tensor)
     tensor_max = torch.max(clipped_tensor)
@@ -185,16 +198,16 @@ def scale_to_0_1(tensor):
     return scaled_tensor
 
 # Function that convolutes a 3D Volume of vectors to find their mean indiscriminative vector
-def vector_convolution(input_tensor, window_size=20, stride=20, device=None):
+def vector_convolution(input_tensor, window_size=20, stride=20, device=None, n_vectors=n_vectors):
     # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     input_tensor = input_tensor.to(device)
     # get the size of your 4D input tensor
     input_size = input_tensor.size()
 
     # initialize an output tensor
-    output_tensor = torch.zeros((input_size[0] - window_size + 1) // stride, 
-                                (input_size[1] - window_size + 1) // stride, 
-                                (input_size[2] - window_size + 1) // stride, 
+    output_tensor = torch.zeros((input_size[0] - window_size + 1) // stride,
+                                (input_size[1] - window_size + 1) // stride,
+                                (input_size[2] - window_size + 1) // stride,
                                 3, device=device)
 
     # slide the window across the 3D volume
@@ -204,14 +217,13 @@ def vector_convolution(input_tensor, window_size=20, stride=20, device=None):
                 # extract the vectors within the window
                 window_vectors = input_tensor[i:i+window_size, j:j+window_size, k:k+window_size]
                 window_vectors = window_vectors.reshape(-1, 3)  # flatten the 3D window into a 2D tensor
-
                 all_zeros = torch.all(window_vectors == 0)
                 if not all_zeros:
                     window_vectors_mask = torch.any(window_vectors != 0, dim=-1)
                     window_vectors = window_vectors[window_vectors_mask]
-                
+
                     # calculate the closest vector
-                    best_vector = find_mean_indiscriminative_vector(window_vectors, 100, device)  # adjust the second parameter as needed
+                    best_vector = find_mean_indiscriminative_vector(window_vectors, n_vectors, device)  # adjust the second parameter as needed
                 else:
                     best_vector = torch.tensor([1.0, 0.0, 0.0], device=device)
                 # check if the indices are within the output_tensor's dimension
@@ -220,6 +232,7 @@ def vector_convolution(input_tensor, window_size=20, stride=20, device=None):
                     output_tensor[i//stride, j//stride, k//stride] = best_vector
 
     return output_tensor
+
 
 # Function that interpolates the output tensor to the original size of the input tensor
 def interpolate_to_original(input_tensor, output_tensor):
@@ -247,10 +260,10 @@ def adjust_vectors_to_global_direction(input_tensor, global_reference_vector):
     # The resulting tensor will have the same shape as the input tensor, but with the last dimension squeezed out.
     global_reference_vector = global_reference_vector.unsqueeze(0).unsqueeze(0).unsqueeze(0).expand(input_tensor.shape)
     dot_products = (input_tensor * global_reference_vector).sum(dim=-1, keepdim=True)
-    # Create a mask of the same shape as the dot products tensor, 
+    # Create a mask of the same shape as the dot products tensor,
     # with True wherever the dot product is negative.
     mask = dot_products < 0
-    
+
     # Expand the mask to have the same shape as the input tensor
     mask = mask.expand(input_tensor.shape)
     # print(f"Input tensor shape: {input_tensor.shape}, dot products shape: {dot_products.shape}, mask shape: {mask.shape}")
@@ -258,7 +271,6 @@ def adjust_vectors_to_global_direction(input_tensor, global_reference_vector):
     # Negate all vectors in the input tensor where the mask is True.
     adjusted_tensor = input_tensor.clone()
     adjusted_tensor[mask] = -input_tensor[mask]
-
     return adjusted_tensor
 
 def subsample_uniform(points, n_samples):
@@ -275,14 +287,14 @@ def surface_detection(volume, global_reference_vector, blur_size=3, sobel_chunks
     # Blur the volume
     blur = uniform_blur3d(channels=1, size=blur_size, device=device)
     blurred_volume = blur(volume.unsqueeze(0).unsqueeze(0)).squeeze(0).squeeze(0)
-    
+
     # Apply Sobel filter to the blurred volume
     sobel_vectors = sobel_filter_3d(blurred_volume, chunks=sobel_chunks, overlap=sobel_overlap, device=device)
-    
+
     # Subsample the sobel_vectors
     sobel_stride = 10
     sobel_vectors_subsampled = sobel_vectors[::sobel_stride, ::sobel_stride, ::sobel_stride, :]
-    
+
     # Apply vector convolution to the Sobel vectors
     vector_conv = vector_convolution(sobel_vectors_subsampled, window_size=window_size, stride=stride, device=device)
 
@@ -294,14 +306,14 @@ def surface_detection(volume, global_reference_vector, blur_size=3, sobel_chunks
 
     # Project the Sobel result onto the adjusted vectors and calculate the norm
     first_derivative = adjusted_norm(sobel_vectors, adjusted_vectors_interp)
-    
+
     first_derivative = scale_to_0_1(first_derivative)
 
     # Apply Sobel filter to the first derivative, project it onto the adjusted vectors, and calculate the norm
     sobel_vectors_derivative = sobel_filter_3d(first_derivative, chunks=sobel_chunks, overlap=sobel_overlap, device=device)
     second_derivative = adjusted_norm(sobel_vectors_derivative, adjusted_vectors_interp)
     second_derivative = scale_to_0_1(second_derivative)
-    
+
     # Generate recto side of sheet
 
     # Create a mask for the conditions on the first and second derivatives
@@ -310,7 +322,7 @@ def surface_detection(volume, global_reference_vector, blur_size=3, sobel_chunks
     points_to_mark = torch.where(mask)
 
     coords = torch.stack(points_to_mark, dim=1)
-    
+
     # Cluster the surface points
     coords_normals = adjusted_vectors_interp[coords[:, 0], coords[:, 1], coords[:, 2]]
 
@@ -323,15 +335,15 @@ def surface_detection(volume, global_reference_vector, blur_size=3, sobel_chunks
     points_to_mark_verso = torch.where(mask_verso)
 
     coords_verso = torch.stack(points_to_mark_verso, dim=1)
-    
+
     # Cluster the surface points
     coords_normals_verso = adjusted_vectors_interp[coords_verso[:, 0], coords_verso[:, 1], coords_verso[:, 2]]
     coords_normals_verso = coords_normals_verso / torch.norm(coords_normals_verso, dim=1, keepdim=True)
-    
+
     if convert_to_numpy:
         coords = coords.cpu().numpy()
         coords_normals = coords_normals.cpu().numpy()
-        
+
         coords_verso = coords_verso.cpu().numpy()
         coords_normals_verso = coords_normals_verso.cpu().numpy()
 
@@ -344,7 +356,7 @@ class TestNormalize(unittest.TestCase):
         vectors = torch.tensor([[1.0, 0, 0], [0, 2.0, 0], [0, 0, 0.1], [0.2, 0.5, 10.35]])
         normalized_vectors = normalize(vectors)
         self.assertTrue(torch.allclose(normalized_vectors.norm(dim=-1), torch.ones(4)))
-        
+
 class TestAngularDistance(unittest.TestCase):
     def test_angular_distance(self):
         v1 = torch.tensor([1.0, 0, 0])
@@ -358,31 +370,31 @@ class TestFindMeanIndiscriminativeVector(unittest.TestCase):
         vectors = torch.tensor([[1.0, 0.0, 0.0]]).to(device)
         best_vector = find_mean_indiscriminative_vector(vectors, 10000, device)
         self.assertTrue(torch.allclose(best_vector, vectors[0], atol=5e-02) or torch.allclose(best_vector, -vectors[0], atol=5e-02))
-        
+
     def test_opposite_vectors(self):
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         vectors = torch.tensor([[0.1, 10.0, 0.0], [-0.1, 10.0, 0.0]]).to(device)
-        best_vector = find_mean_indiscriminative_vector(vectors, 10000)
-        self.assertTrue(torch.allclose(best_vector, torch.tensor([0.0, 1.0, 0.0]), atol=5e-02) or torch.allclose(best_vector, torch.tensor([0.0, -1.0, 0.0]), atol=5e-02))
-        
+        best_vector = find_mean_indiscriminative_vector(vectors, 10000, device)
+        self.assertTrue(torch.allclose(best_vector, torch.tensor([0.0, 1.0, 0.0]).to(device), atol=5e-02) or torch.allclose(best_vector, torch.tensor([0.0, -1.0, 0.0]).to(device), atol=5e-02))
+
 class TestAdjustMeanVectorAmplitude(unittest.TestCase):
     def test_adjust_mean_vector_amplitude(self):
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        vectors = torch.tensor([[1.5, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 0.1], [0.2, 0.5, 10.35]])
-        mean_vector = find_mean_indiscriminative_vector(vectors, 1000).to(device)
+        vectors = torch.tensor([[1.5, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 0.1], [0.2, 0.5, 10.35]]).to(device)
+        mean_vector = find_mean_indiscriminative_vector(vectors, 1000, device)
         adjusted_mean_vector = adjust_mean_vector_amplitude(mean_vector, vectors)
         self.assertTrue(torch.allclose(adjusted_mean_vector.norm(dim=-1), vectors.norm(dim=-1).mean(), atol=5e-02))
-        
+
 class TestVectorProjection(unittest.TestCase):
     def test_vector_projection(self):
         v1 = torch.tensor([1.0, 0.0, 0.0])
         v2 = torch.tensor([0.0, 1.0, 0.0])
         self.assertTrue(torch.allclose(vector_projection(v1, v2), torch.tensor([0.0, 0.0, 0.0])))
-        
+
     def test_vector_projection2(self):
         v1 = torch.tensor([1.0, 0.0, 0.0])
         v2 = torch.tensor([1.0, 0.0, 0.0])
         self.assertTrue(torch.allclose(vector_projection(v1, v2), torch.tensor([1.0, 0.0, 0.0])))
-        
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Collectively these changes improved the speed of the pointcloud calculations by ~30% on my hardware.  We cache the sobel kernel creation, reduce calls to clear the cuda cache, JIT the inner action of the mean indiscriminate vector, and remove a redundant angular distance calculation.

All existing tests remain passing.